### PR TITLE
Add 'View the app' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ We use Hugo to format and generate our website, the Docsy theme for styling and 
 
 1. **Fork** this repo
 2. Clone your fork and `cd` into the repo:
+
    ```
    git clone https://github.com/target/consensource-docs.git
    cd consensource-docs/
@@ -16,31 +17,32 @@ We use Hugo to format and generate our website, the Docsy theme for styling and 
 3. Download Hugo v0.59.1 extended [from the project's release page](https://github.com/gohugoio/hugo/releases/tag/v0.59.1). The extended version is required for our SCSS pre-processing. Move the binary to your `PATH`, e.g for a MacOS user:
    ```
    cp ~/Downloads/hugo_0.59.1_macOS-64bit/hugo /usr/local/bin/
-   ````
+   ```
 4. Install required npm dependencies:
    ```
    npm i
    ```
 5. Start the web server:
 
-    ```
-    hugo server -D
-    ```
+   ```
+   hugo server -D
+   ```
 
 **Note**: Any Hugo version above v0.59.1 will be incompatable with the current docs site [due to the new Markdown library introduced in v0.60.0](https://gohugo.io/news/0.60.0-relnotes/).
 
 ## Updating the live docs site
 
-The [GitHub Pages config](https://github.com/target/consensource-docs/settings) for this site is set to republish on any updates to the `docs` folder in the `master` branch. 
+The [GitHub Pages config](https://github.com/target/consensource-docs/settings) for this site is set to republish on any updates to the `docs` folder in the `master` branch.
 In our [config.toml](https://github.com/target/consensource-docs/blob/master/config.toml#L3), we have also configured Hugo to output it's build process to our `docs` folder.
 
 To publish a new update to the live docs site:
-1. Run the `hugo` command from the root of the project - this will populate the `docs` folder with your new content.
+
+1. Run the `HUGO_ENV=production hugo` from the root of the project - this will run a production build and populate the `docs` folder with your new content.
 2. Open a PR to the `master` branch from your fork
 3. When that PR is merged, the docs site will automatically republish.
 
-
 ### Useful resources
+
 - [User guide for the Docsy theme](https://www.docsy.dev/docs/getting-started/)
 - [Hugo installation guide](https://gohugo.io/getting-started/installing/)
 - [Hugo basic usage](https://gohugo.io/getting-started/usage/)
@@ -50,15 +52,16 @@ To publish a new update to the live docs site:
 ## ConsenSource Docs Site Layout
 
 ### Navbar
-The site theme has one Hugo menu (`main`), which defines the top navigation bar. 
-You can find and adjust the definition of the menu in the [site configuration 
-file](https://github.com/target/consensource-docs/blob/master/config.toml). 
 
-The left-hand navigation panel is defined by the directory structure under 
-the 
-[`docs` directory](https://github.com/target/consensource-docs/tree/master/content/docs). 
+The site theme has one Hugo menu (`main`), which defines the top navigation bar.
+You can find and adjust the definition of the menu in the [site configuration
+file](https://github.com/target/consensource-docs/blob/master/config.toml).
 
-A `weight` property in the _front matter_ of each page determines the position 
+The left-hand navigation panel is defined by the directory structure under
+the
+[`docs` directory](https://github.com/target/consensource-docs/tree/master/content/docs).
+
+A `weight` property in the _front matter_ of each page determines the position
 of the page relative to the others in the same directory. The lower the weight,
 the earlier the page appears in the section. A weight of 1 appears before a
 a weight of 2, and so on. For example, see the front matter of the
@@ -75,7 +78,7 @@ description: A high-level overview of the ConsenSource application
 
 ### Docs sidebar
 
-The sidebar menu in the `docs` folder is automatically constructed by Docsy. The structure is based off of the folder structure in the `docs` folder - each subfolder that contains 
+The sidebar menu in the `docs` folder is automatically constructed by Docsy. The structure is based off of the folder structure in the `docs` folder - each subfolder that contains
 an `_index.md` file will create a new section in the sidebar. Siblings of the `_index.md` for a given folder will be displayed underneath the section for that folder with the value of `title` or
 `linkTitle` in the front matter for the page.
 
@@ -83,42 +86,42 @@ More info on the Docs sidebar can be found in the [Docsy documentation](https://
 
 ## Working with the theme
 
-The theme files are in the 
+The theme files are in the
 [`themes/docsy` directory](https://github.com/target/consensource-docs/tree/master/themes/docsy).
 **Do not change these files**, because they are overwritten each time we update
-the website to a  later version of the theme, and your changes will be lost.
+the website to a later version of the theme, and your changes will be lost.
 
 ## Styling your content
 
-The theme holds its styles in the 
+The theme holds its styles in the
 [`assets/scss` directory](https://github.com/target/consensource-docs/tree/master/assets/scss).
 **Do not change these files**, because they are overwritten each time we update
-the website to a  later version of the theme, and your changes will be lost.
+the website to a later version of the theme, and your changes will be lost.
 
 You can override the default styles and add new ones:
 
-* In general, put your files in the project directory structure under `website` 
+- In general, put your files in the project directory structure under `website`
   rather than in the theme directory. Use the same file name as the theme does,
-  and put the file in the same relative position. Hugo looks first at the file 
-  in the main project directories, if present, then at the files under the theme 
+  and put the file in the same relative position. Hugo looks first at the file
+  in the main project directories, if present, then at the files under the theme
   directory.
-* You can update the ConsenSource docs site project variables in the 
+- You can update the ConsenSource docs site project variables in the
   [`_variables_project.scss` file](https://github.com/target/consensource-docs/blob/master/assets/scss/_variables_project.scss).
   Values in that file override the
   [Docsy variables](https://github.com/target/consensource-docs/blob/master/themes/docsy/assets/scss/_variables_project.scss).
-  You can also use `_variables_project.scss` to specify your own values for any 
-  of the default 
+  You can also use `_variables_project.scss` to specify your own values for any
+  of the default
   [Bootstrap 4 variables](https://getbootstrap.com/docs/4.0/getting-started/theming/).
 
 The site's [front page](https://www.example.org/):
 
-* See the [page source](https://github.com/target/consensource-docs/blob/master/content/_index.html).
-* The CSS styles are in the 
+- See the [page source](https://github.com/target/consensource-docs/blob/master/content/_index.html).
+- The CSS styles are in the
   [project variables file](https://github.com/target/consensource-docs/blob/master/assets/scss/_variables_project.scss).
-* The page uses the 
-  [cover block](https://www.docsy.dev/docs/adding-content/shortcodes/#blocks-cover) 
+- The page uses the
+  [cover block](https://www.docsy.dev/docs/adding-content/shortcodes/#blocks-cover)
   defined by the theme.
-* The page also uses the 
+- The page also uses the
   [linkdown block](https://www.docsy.dev/docs/adding-content/shortcodes/#blocks-link-down).
 
 ## Using Hugo shortcodes
@@ -135,7 +138,7 @@ shortcode file when the page is built.
 
 To create a shortcode:
 
-1. Add an HTML file in  the `/website/layouts/shortcodes/` directory.
+1. Add an HTML file in the `/website/layouts/shortcodes/` directory.
    The file name must be short and meaningful, as it determines the shortcode
    you and others use in the docs.
 
@@ -145,13 +148,14 @@ To create a shortcode:
 To use a shortcode in a document, wrap the name of the shortcode in braces and
 percent signs like this:
 
-  ```
-  {{% shortcode-name %}}
-  ```
+```
+{{% shortcode-name %}}
+```
 
 The shortcode name is the file name minus the `.html` file extension.
 
 Useful Hugo docs:
+
 - [Shortcode templates](https://gohugo.io/templates/shortcode-templates/)
 - [Shortcodes](https://gohugo.io/content-management/shortcodes/)
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -92,7 +92,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -94,7 +94,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/business/context-problem-statement/index.html
+++ b/docs/docs/business/context-problem-statement/index.html
@@ -100,7 +100,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/business/dlt-overview/index.html
+++ b/docs/docs/business/dlt-overview/index.html
@@ -100,7 +100,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/business/index.html
+++ b/docs/docs/business/index.html
@@ -94,7 +94,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/business/value-proposition/index.html
+++ b/docs/docs/business/value-proposition/index.html
@@ -100,7 +100,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/api/rest-api/index.html
+++ b/docs/docs/developer/application-developers-guide/api/rest-api/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/architecture-overview/index.html
+++ b/docs/docs/developer/application-developers-guide/architecture-overview/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/cli/cli/index.html
+++ b/docs/docs/developer/application-developers-guide/cli/cli/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/client/certifying-body/index.html
+++ b/docs/docs/developer/application-developers-guide/client/certifying-body/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/client/factory/index.html
+++ b/docs/docs/developer/application-developers-guide/client/factory/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/client/index.html
+++ b/docs/docs/developer/application-developers-guide/client/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/client/retailer/index.html
+++ b/docs/docs/developer/application-developers-guide/client/retailer/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/client/standards-body/index.html
+++ b/docs/docs/developer/application-developers-guide/client/standards-body/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/index.html
+++ b/docs/docs/developer/application-developers-guide/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/sds/state-delta-subscriber/index.html
+++ b/docs/docs/developer/application-developers-guide/sds/state-delta-subscriber/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/application-developers-guide/tp/transaction-processor-and-famlies/index.html
+++ b/docs/docs/developer/application-developers-guide/tp/transaction-processor-and-famlies/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/community/index.html
+++ b/docs/docs/developer/community/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/gcp/gcp/index.html
+++ b/docs/docs/developer/getting-started/gcp/gcp/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/index.html
+++ b/docs/docs/developer/getting-started/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/local/index.html
+++ b/docs/docs/developer/getting-started/local/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/local/linux/index.html
+++ b/docs/docs/developer/getting-started/local/linux/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/local/mac/index.html
+++ b/docs/docs/developer/getting-started/local/mac/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/getting-started/local/windows/index.html
+++ b/docs/docs/developer/getting-started/local/windows/index.html
@@ -103,7 +103,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/index.html
+++ b/docs/docs/developer/index.html
@@ -94,7 +94,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/parameter-reference/index.html
+++ b/docs/docs/developer/parameter-reference/index.html
@@ -105,7 +105,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/terminology/index.html
+++ b/docs/docs/developer/terminology/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/developer/troubleshooting/index.html
+++ b/docs/docs/developer/troubleshooting/index.html
@@ -97,7 +97,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -94,7 +94,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,7 +94,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -99,7 +99,10 @@ if (!doNotTrack) {
         <a class="dropdown-item" href="/consensource-docs/docs/developer">Developer</a>
     </div>
     
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			
 			
 		</ul>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -19,7 +19,10 @@
             {{ end }}
             <li class="nav-item dropdown d-none d-lg-block">
                 {{ partial "navbar-docs-selector.html" . }}
-            </li>
+			</li>
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+				<a class="nav-link" href="http://consensource.org" target=_blank>View the app</a>
+			</li>
 			{{ if  .Site.Params.versions }}
 			<li class="nav-item dropdown d-none d-lg-block">
 				{{ partial "navbar-version-selector.html" . }}


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

- Adds a `View the app` link that directs to http://consensource.org
- Updates the docs with instructions on performing a production build

## Types of changes

What types of changes does this pull request introduce to ConsenSource docs? _Put an `x` in the boxes that apply_

- [ ] Fix
- [x] New documentation
